### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/contracts/stellar/scripts/protocol.mjs
+++ b/contracts/stellar/scripts/protocol.mjs
@@ -80,7 +80,7 @@ const networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE || Networks.TES
 console.log('-------------------------------------------------------');
 console.log('Configuration:');
 console.log('RPC URL:', rpcUrl);
-console.log('Network Passphrase:', networkPassphrase);
+console.log('Network Passphrase: [REDACTED]');
 console.log('Protocol Contract ID:', PROTOCOL_CONTRACT_ID);
 console.log('Admin Address:', ADMIN_ADDRESS || 'Not Set');
 console.log('-------------------------------------------------------');


### PR DESCRIPTION
Potential fix for [https://github.com/daccred/attest.so/security/code-scanning/1](https://github.com/daccred/attest.so/security/code-scanning/1)

To fix the issue, we will remove the logging of the `networkPassphrase` variable. Instead, we can log a generic message indicating that the network passphrase is set without revealing its value. This ensures that no sensitive information is exposed in the logs while still providing useful feedback to the user.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
