### PR TITLE
Fix attestation typo in SAS.cairo

### DIFF
--- a/contracts/starknet/src/SAS.cairo
+++ b/contracts/starknet/src/SAS.cairo
@@ -557,8 +557,8 @@ mod SAS {
             // let mut _uids: Array<u256> = ArrayTrait::new();
             // _uids.append(uid);
             let mut result: AttestationsResult = AttestationsResult { usedValue: 0, uids: uid };
-            let mut lastAttastationCount: u256 = self._noOfAttestation.read(schemaUID);
-            self._noOfAttestation.write(schemaUID, lastAttastationCount + 1);
+            let mut lastAttestationCount: u256 = self._noOfAttestation.read(schemaUID);
+            self._noOfAttestation.write(schemaUID, lastAttestationCount + 1);
             self
                 .emit(
                     Event::Attested(
@@ -577,16 +577,16 @@ mod SAS {
         /// @dev Calculates a UID for a given schema.
         /// @param schemaRecord The input schema.
         /// @return schema UID.
-        fn _getUID(ref self: ContractState, _attestaion: Attestation, _bump: u32) -> u256 {
+        fn _getUID(ref self: ContractState, _attestation: Attestation, _bump: u32) -> u256 {
             let mut input_array: Array<u256> = ArrayTrait::new();
-            let schema: u256 = _attestaion.schema;
-            // let recipient = _attestaion.recipient;
-            // let attester: u256 = _attestaion.attester.into();
-            let time: u256 = _attestaion.time.into();
-            let expirationTime: u256 = _attestaion.expirationTime.into();
-            // let revocable: u256 = _attestaion.revocable.into();
-            let refUID: u256 = _attestaion.refUID;
-            // let data: u256 = _attestaion.data.into();
+            let schema: u256 = _attestation.schema;
+            // let recipient = _attestation.recipient;
+            // let attester: u256 = _attestation.attester.into();
+            let time: u256 = _attestation.time.into();
+            let expirationTime: u256 = _attestation.expirationTime.into();
+            // let revocable: u256 = _attestation.revocable.into();
+            let refUID: u256 = _attestation.refUID;
+            // let data: u256 = _attestation.data.into();
             input_array.append(schema);
             // input_array.append(recipient);
             // input_array.append(attester);


### PR DESCRIPTION
## Summary
- fix `_attestaion` typo in SAS.cairo
- update mispelled variable names

## Testing
- `scarb build` *(fails: command not found)*
- `snforge test` *(fails: command not found)*