### PR TITLE
Implement network passphrase logic

### DIFF
--- a/packages/stellar-cli/src/handlers/stellar.ts
+++ b/packages/stellar-cli/src/handlers/stellar.ts
@@ -5,6 +5,7 @@ import { BaseHandler } from './base'
 import { validateStellarSchema, validateStellarAttestation } from '../utils'
 import { Command } from 'commander'
 import { Keypair } from '@stellar/stellar-sdk'
+import * as StellarSdk from '@stellar/stellar-sdk'
 import AttestSDK, {
   StellarAttestationConfig,
   SchemaConfig,
@@ -34,15 +35,14 @@ export class StellarHandler extends BaseHandler {
 
   // Get the network passphrase based on the network configuration
   private getNetworkPassphrase(): string {
-    // switch (this.network) {
-    //   case 'public':
-    //   case 'mainnet':
-    //     return StellarSdk.Networks.PUBLIC
-    //   case 'testnet':
-    //   default:
-    //     return StellarSdk.Networks.TESTNET
-    // }
-    return ''
+    switch (this.network.toLowerCase()) {
+      case 'public':
+      case 'mainnet':
+        return StellarSdk.Networks.PUBLIC
+      case 'testnet':
+      default:
+        return StellarSdk.Networks.TESTNET
+    }
   }
 
   async check(action: string, args: any): Promise<boolean> {


### PR DESCRIPTION
## Summary
- choose passphrase based on CLI network option

## Testing
- `pnpm --filter @attestprotocol/stellar-cli build` *(fails: tsup-node not found)*
- `pnpm --filter @attestprotocol/stellar-cli test` *(fails: jest not found)*