### PR TITLE
Update Prisma schema for attestations

### DIFF
--- a/apps/horizon/prisma/migrations/20251107132345_add_contract_address_to_schemas_and_attestations/migration.sql
+++ b/apps/horizon/prisma/migrations/20251107132345_add_contract_address_to_schemas_and_attestations/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "attestations" ADD COLUMN "contractAddress" TEXT NOT NULL DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "schemas" ADD COLUMN "contractAddress" TEXT NOT NULL DEFAULT '';
+
+-- CreateIndex
+CREATE INDEX "attestations_contractAddress_idx" ON "attestations"("contractAddress");
+
+-- CreateIndex
+CREATE INDEX "schemas_contractAddress_idx" ON "schemas"("contractAddress");

--- a/apps/horizon/prisma/migrations/20251107132345_add_contract_address_to_schemas_and_attestations/migration.sql
+++ b/apps/horizon/prisma/migrations/20251107132345_add_contract_address_to_schemas_and_attestations/migration.sql
@@ -1,8 +1,8 @@
 -- AlterTable
-ALTER TABLE "attestations" ADD COLUMN "contractAddress" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "attestations" ADD COLUMN "contractAddress" TEXT NOT NULL DEFAULT 'CDBWGWEZ3P4DZ3YUZSCEUKOVV2UGF2PYQEPW3E5OKNLYS5SNW4SQLDUA';
 
 -- AlterTable
-ALTER TABLE "schemas" ADD COLUMN "contractAddress" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "schemas" ADD COLUMN "contractAddress" TEXT NOT NULL DEFAULT 'CDBWGWEZ3P4DZ3YUZSCEUKOVV2UGF2PYQEPW3E5OKNLYS5SNW4SQLDUA';
 
 -- CreateIndex
 CREATE INDEX "attestations_contractAddress_idx" ON "attestations"("contractAddress");

--- a/apps/horizon/prisma/schema.prisma
+++ b/apps/horizon/prisma/schema.prisma
@@ -185,24 +185,26 @@ model Attestation {
   message           String   // Raw JSON value or message
   value             Json?    // Optional parsed fields
   revoked           Boolean  @default(false)
-  
+  contractAddress   String   // Contract that emitted this attestation
+
   // Timestamps
   createdAt         DateTime?  // Nullable - should be filled with blockchain timestamp
   revokedAt         DateTime?
-  
+
   // Relations - keeping schemaUid as regular field without foreign key constraint
   // This allows attestations to reference schemas by UID without database-level enforcement
-  
+
   // Indexer metadata
   ingestedAt        DateTime @default(now())
   lastUpdated       DateTime @updatedAt
-  
+
   @@index([ledger])
   @@index([schemaUid])
   @@index([attesterAddress])
   @@index([subjectAddress])
   @@index([revoked])
   @@index([createdAt])
+  @@index([contractAddress])
   @@map("attestations")
 }
 
@@ -217,23 +219,25 @@ model Schema {
   deployerAddress           String
   type                      String   @default("default") // Category label
   transactionHash           String
-  
+  contractAddress           String   // Contract that registered this schema
+
   // Timestamps
   createdAt                 DateTime?  // Nullable - should be filled with blockchain timestamp
-  
+
   // Relations - removed to eliminate foreign key constraints
   // attestations can still reference schemas via schemaUid field
-  
+
   // Indexer metadata
   ingestedAt                DateTime @default(now())
   lastUpdated               DateTime @updatedAt
-  category                  String   @default("default") 
+  category                  String   @default("default")
   featured                  Boolean  @default(false)
-  
+
   @@index([ledger])
   @@index([deployerAddress])
   @@index([type])
   @@index([createdAt])
+  @@index([contractAddress])
   @@map("schemas")
 }
 

--- a/apps/horizon/src/repository/attestations.repository.ts
+++ b/apps/horizon/src/repository/attestations.repository.ts
@@ -50,6 +50,7 @@ export interface AttestationData {
   revoked?: boolean
   revokedAt?: Date
   createdAt?: Date  // Add optional createdAt to preserve blockchain timestamp
+  contractAddress: string  // Contract that emitted this attestation
 }
 
 /**
@@ -87,6 +88,7 @@ export async function singleUpsertAttestation(attestationData: AttestationData) 
         revoked: attestationData.revoked || false,
         revokedAt: attestationData.revokedAt,
         createdAt: attestationData.createdAt,  // Use blockchain timestamp only - no fallback
+        contractAddress: attestationData.contractAddress,
       },
       // Removed schema include due to removed foreign key constraint
     })
@@ -291,6 +293,7 @@ export async function bulkUpsertAttestations(attestations: AttestationData[]) {
               revoked: attestationData.revoked || false,
               revokedAt: attestationData.revokedAt,
               createdAt: attestationData.createdAt,  // Use blockchain timestamp only - no fallback
+              contractAddress: attestationData.contractAddress,
             },
           })
           processedCount++

--- a/apps/horizon/src/repository/ingest.repository.ts
+++ b/apps/horizon/src/repository/ingest.repository.ts
@@ -650,6 +650,7 @@ async function upsertEventIndividually(db: any, eventData: EventData, operationI
           type: 'default',
           transactionHash: eventData.transactionHash,
           createdAt: new Date(eventData.timestamp),  // Use blockchain timestamp
+          contractAddress: eventData.contractId,
         })
       } else {
         console.log('⚠️ [Projection] SCHEMA missing expected fields', { schemaUidType: typeof val[0], objType: typeof val[1] })
@@ -702,6 +703,7 @@ async function upsertEventIndividually(db: any, eventData: EventData, operationI
           value,
           revoked: false,
           createdAt: new Date(eventData.timestamp),  // Use blockchain timestamp
+          contractAddress: eventData.contractId,
         })
       } else {
         console.log('⚠️ [Projection] ATTEST create missing ids', { attestationUid: !!attestationUid, schemaUid: !!schemaUid, attester: !!attesterAddress })
@@ -757,6 +759,7 @@ async function upsertEventIndividually(db: any, eventData: EventData, operationI
           revoked: revokedFlag === true,
           revokedAt,
           createdAt: new Date(eventData.timestamp),  // Use blockchain timestamp
+          contractAddress: eventData.contractId,
         })
       } else {
         console.log('⚠️ [Projection] ATTEST revoke missing required fields', { 

--- a/apps/horizon/src/repository/schemas.repository.ts
+++ b/apps/horizon/src/repository/schemas.repository.ts
@@ -45,6 +45,7 @@ export interface SchemaData {
   type?: string
   transactionHash: string
   createdAt?: Date  // Add optional createdAt to preserve blockchain timestamp
+  contractAddress: string  // Contract that registered this schema
 }
 
 /**
@@ -79,6 +80,7 @@ export async function singleUpsertSchema(schemaData: SchemaData) {
         type: schemaData.type || 'default',
         transactionHash: schemaData.transactionHash,
         createdAt: schemaData.createdAt,  // Use blockchain timestamp only - no fallback
+        contractAddress: schemaData.contractAddress,
       },
       // Removed attestations include due to removed foreign key constraint
     })
@@ -282,6 +284,7 @@ export async function bulkUpsertSchemas(schemas: SchemaData[]) {
               type: schemaData.type || 'default',
               transactionHash: schemaData.transactionHash,
               createdAt: schemaData.createdAt,  // Use blockchain timestamp only - no fallback
+              contractAddress: schemaData.contractAddress,
             },
           })
           processedCount++


### PR DESCRIPTION
Add contractAddress field to Schema and Attestation models to track which contract registered/emitted each record. This enables multi-contract support and better data provenance tracking.

Changes:
- Add contractAddress column to schemas and attestations tables
- Update TypeScript interfaces in repository files
- Pass contractAddress from eventData.contractId during ingestion
- Create database migration with indexes for efficient queries

## I have read the [CONTRIBUTING.md](https://github.com/daccred/attest.so/blob/main/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
