### PR TITLE
Document authorities and custom resolvers

### DIFF
--- a/apps/docs/concepts/authorities.mdx
+++ b/apps/docs/concepts/authorities.mdx
@@ -1,50 +1,58 @@
 ---
 title: "Authorities"
-description: "The trust layer that governs schema ownership and verification"
+description: "Schema ownership and verified issuer status"
 ---
 
 ## What is an Authority?
 
-Every wallet address that deploys a schema automatically becomes the **authority** of that schema. This means you control who can issue attestations, set the resolver rules, and manage revocations for your schema.
+In AttestProtocol, an **authority** is simply the wallet address that created a schema. When you deploy a schema, you become its authority — the permanent owner of that schema definition.
 
 <Note>
-You don't need to register as an authority to create schemas. Any wallet can deploy a schema and become its authority automatically.
+Schemas and attestations are **permissionless by default**. Anyone can create schemas, and anyone can issue attestations to any schema — unless a resolver restricts access.
 </Note>
 
-## Schema Authority vs Verified Authority
+## The Permissionless Model
 
-There are two levels of authority in AttestProtocol:
+AttestProtocol is designed to be open:
 
-| Type | Description | Requirements |
-|------|-------------|--------------|
-| **Schema Authority** | Automatic ownership when you deploy a schema | Just deploy a schema |
-| **Verified Authority** | Platform verification with badge and trust signals | Register + verify credentials |
+| Action | Default Behavior | With Resolver |
+|--------|------------------|---------------|
+| **Create Schema** | Anyone can create | Anyone can create |
+| **Issue Attestation** | Anyone can attest to any schema | Resolver controls access |
+| **Revoke Attestation** | Original attester can revoke | Resolver controls access |
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                      AUTHORITY MODEL                        │
+│                   PERMISSIONLESS BY DEFAULT                 │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│   Any Wallet                                                │
-│   └── Deploys Schema ──► Becomes Schema Authority           │
-│       ├── Controls schema resolver                          │
-│       ├── Issues attestations                               │
-│       └── Manages revocations                               │
+│   Schema Creation                                           │
+│   └── Any wallet can deploy a schema                        │
+│       └── Creator becomes the "authority" (owner)           │
 │                                                             │
-│   ─────────────────────────────────────────────────────     │
+│   Attestation Issuance                                      │
+│   └── Any wallet can attest to any schema                   │
+│       └── Unless a resolver restricts access                │
 │                                                             │
-│   Verified Authority (Optional)                             │
-│   └── Registers + Verifies ──► Gets Platform Badge          │
-│       ├── stellar.toml verification                         │
-│       ├── DID/Verifiable Credentials                        │
-│       └── External credential verification                  │
+│   Access Control (Optional)                                 │
+│   └── Attach a resolver to control who can attest           │
+│       ├── Fee requirements                                  │
+│       ├── Allowlists                                        │
+│       └── Custom validation logic                           │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## Schema Authority (Automatic)
+## Schema Authority
 
-When you deploy a schema, your wallet address is recorded as its authority. This gives you permanent control over that schema.
+When you deploy a schema, your wallet address is recorded as its **authority**. This gives you:
+
+- **Ownership record** — Your address is permanently linked to the schema
+- **Schema definition control** — You defined the structure and resolver at creation
+
+<Warning>
+Being a schema authority does **not** mean only you can attest. By default, anyone can issue attestations to your schema. Use a [resolver](/concepts/resolvers) if you need access control.
+</Warning>
 
 ### Creating a Schema
 
@@ -56,42 +64,42 @@ const attest = new StellarAttest({
   contractId: 'CBFE5YSUHCRYEYEOLNN2RJAWMQ2PW525KTJ6TPWPNS5XLIREZQ3NA4KP'
 });
 
-// Deploy a schema - you automatically become its authority
+// Deploy a schema - you become its authority
 const schemaUid = await attest.schema.register({
   schema: 'string name, bool verified, uint64 timestamp',
-  resolver: resolverAddress, // Optional custom resolver
+  resolver: null,  // No resolver = permissionless attestations
   revocable: true
 });
 
-// Your wallet is now the authority of this schema
+// Anyone can now attest to this schema
 ```
 
-### Authority Permissions
+### Restricting Access with Resolvers
 
-As a schema authority, you can:
+If you want to control who can attest to your schema, attach a resolver:
 
-| Permission | Description |
-|------------|-------------|
-| **Issue Attestations** | Create verifiable claims following your schema |
-| **Revoke Attestations** | Invalidate previously issued attestations (if schema allows) |
-| **Set Resolver** | Define custom validation rules at schema creation |
-| **Delegate Signing** | Allow delegates to sign on your behalf (via BLS delegation) |
+```typescript
+// Deploy a schema with access control
+const schemaUid = await attest.schema.register({
+  schema: 'string credential, uint64 issuedAt',
+  resolver: 'CRESOLVER...', // Resolver controls who can attest
+  revocable: true
+});
 
-<Info>
-Schema ownership is permanent. Once you deploy a schema, the authority field cannot be changed.
-</Info>
+// Now only addresses approved by the resolver can attest
+```
+
+See [Custom Resolvers](/concepts/resolvers) for details on implementing access control.
 
 ## Verified Authority (Optional)
 
-Becoming a **Verified Authority** is optional but provides trust signals on the AttestProtocol platform:
+Separately from schema authority, you can register as a **Verified Authority** on the AttestProtocol platform. This is completely optional and provides:
 
 - **Platform badge** — Visual indicator that you're a verified issuer
 - **Trust signals** — Users can see your verification status
 - **Discovery** — Easier for verifiers to find trusted attestation sources
 
 ### Verification Methods
-
-You can verify your authority through multiple methods:
 
 <CardGroup cols={2}>
   <Card title="stellar.toml" icon="star">
@@ -105,9 +113,9 @@ You can verify your authority through multiple methods:
 ### Registering as a Verified Authority
 
 ```typescript
-// Register for verified authority status
+// Register for verified authority status (optional)
 const result = await attest.authority.registerAuthority(
-  'GAUTHORITY...', // Your authority address
+  'GAUTHORITY...', // Your address
   JSON.stringify({
     name: 'Acme Verification Inc.',
     website: 'https://acme.com',
@@ -140,16 +148,6 @@ When registering as a verified authority, include relevant information:
 
 ## Checking Authority Status
 
-### Check Schema Authority
-
-Every attestation includes the attester address, letting verifiers know who issued it:
-
-```typescript
-// Get attestation details
-const attestation = await attest.getAttestation(attestationUid);
-console.log('Issued by:', attestation.data.attester);
-```
-
 ### Check Verified Authority Status
 
 ```typescript
@@ -161,56 +159,66 @@ const authority = await attest.authority.fetchAuthority('GADDRESS...');
 console.log('Authority:', authority.data);
 ```
 
+### Check Attestation Issuer
+
+Every attestation includes the attester address:
+
+```typescript
+// Get attestation details
+const attestation = await attest.getAttestation(attestationUid);
+console.log('Issued by:', attestation.data.attester);
+```
+
 ## Delegation
 
 Authorities can delegate attestation signing to other addresses using BLS delegation. This enables:
 
 - **Gasless attestations** — Users sign off-chain, a relayer submits on-chain
 - **Batch operations** — Issue many attestations in one transaction
-- **Separation of concerns** — Keep hot wallets separate from authority keys
+- **Separation of concerns** — Keep hot wallets separate from main keys
 
 See [Delegation](/concepts/delegation) for detailed documentation.
 
 ## Authority vs Resolver
 
-While authorities control **who owns schemas**, resolvers control **the rules** for attestation creation:
+| Concept | Purpose | Controls |
+|---------|---------|----------|
+| **Authority** | Schema ownership record | Who created the schema |
+| **Resolver** | Access control & validation | Who can attest, fees, rules |
 
-| Aspect | Authority | Resolver |
-|--------|-----------|----------|
-| **Purpose** | Schema ownership | Enforces business rules |
-| **Assignment** | Automatic on schema creation | Optional, attached to schemas |
-| **Control** | Creates schemas, issues attestations | Validates attestation operations |
-| **Examples** | KYC provider, DAO, certification body | Payment validation, access control |
+- **Authority** = "Who owns this schema definition"
+- **Resolver** = "What rules apply when attesting"
 
-See [Custom Resolvers](/concepts/resolvers) for more on implementing validation logic.
+Without a resolver, attestations are permissionless. With a resolver, you can enforce any access control logic you need.
+
+See [Custom Resolvers](/concepts/resolvers) for implementation details.
 
 ## Security Considerations
 
 <Warning>
-Your authority address controls all schemas you create. Keep your private keys secure.
+Keep your private keys secure. While attestations are permissionless, your verified authority status and any resolver admin rights are tied to your address.
 </Warning>
 
 ### Best Practices
 
-1. **Use a dedicated address** — Don't reuse addresses across protocols
+1. **Use resolvers for access control** — Don't assume only you will attest to your schema
 2. **Secure your keys** — Use hardware wallets or multi-sig for production
 3. **Verify your domain** — Set up stellar.toml for additional trust
-4. **Monitor attestations** — Track what's being issued under your authority
-5. **Plan revocation** — Have a process for revoking compromised attestations
+4. **Monitor attestations** — Track what's being issued to your schemas
 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Create Your First Schema" icon="square-plus" href="/stellar/schemas">
-    Define attestation structures for your use case
-  </Card>
   <Card title="Custom Resolvers" icon="code" href="/concepts/resolvers">
-    Add validation rules to your attestations
+    Add access control to your schemas
+  </Card>
+  <Card title="Create a Schema" icon="square-plus" href="/stellar/schemas">
+    Define attestation structures
   </Card>
   <Card title="Delegation" icon="signature" href="/concepts/delegation">
     Enable off-chain signing with BLS delegation
   </Card>
   <Card title="Examples" icon="book-open" href="/examples/kyc-verification">
-    See real-world authority implementations
+    See real-world implementations
   </Card>
 </CardGroup>

--- a/apps/docs/concepts/authorities.mdx
+++ b/apps/docs/concepts/authorities.mdx
@@ -1,51 +1,52 @@
 ---
 title: "Authorities"
-description: "The trust layer that governs who can issue attestations"
+description: "The trust layer that governs schema ownership and verification"
 ---
 
 ## What is an Authority?
 
-An Authority is a registered entity that has the right to create schemas and issue attestations. Think of authorities as **trusted issuers** — they're the organizations, protocols, or individuals that vouch for the claims being made on-chain.
+Every wallet address that deploys a schema automatically becomes the **authority** of that schema. This means you control who can issue attestations, set the resolver rules, and manage revocations for your schema.
 
 <Note>
-Authorities are the foundation of trust in the attestation ecosystem. Without a registered authority, you cannot create schemas or issue attestations.
+You don't need to register as an authority to create schemas. Any wallet can deploy a schema and become its authority automatically.
 </Note>
 
-## The Authority Model
+## Schema Authority vs Verified Authority
+
+There are two levels of authority in AttestProtocol:
+
+| Type | Description | Requirements |
+|------|-------------|--------------|
+| **Schema Authority** | Automatic ownership when you deploy a schema | Just deploy a schema |
+| **Verified Authority** | Platform verification with badge and trust signals | Register + verify credentials |
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                      AUTHORITY LAYER                        │
+│                      AUTHORITY MODEL                        │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│   Authority                                                 │
-│   ├── Registers with Protocol (pays fee)                   │
-│   ├── Creates Schema(s)                                    │
-│   │   ├── Defines attestation structure                    │
-│   │   ├── Sets resolver (optional)                         │
-│   │   └── Configures revocability                          │
-│   │                                                         │
-│   └── Issues Attestation(s)                                │
-│       ├── Signs claims about subjects                      │
-│       ├── Follows schema structure                         │
-│       └── Can revoke (if schema allows)                    │
+│   Any Wallet                                                │
+│   └── Deploys Schema ──► Becomes Schema Authority           │
+│       ├── Controls schema resolver                          │
+│       ├── Issues attestations                               │
+│       └── Manages revocations                               │
+│                                                             │
+│   ─────────────────────────────────────────────────────     │
+│                                                             │
+│   Verified Authority (Optional)                             │
+│   └── Registers + Verifies ──► Gets Platform Badge          │
+│       ├── stellar.toml verification                         │
+│       ├── DID/Verifiable Credentials                        │
+│       └── External credential verification                  │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## Authority Registration
+## Schema Authority (Automatic)
 
-Before issuing attestations, an authority must register with the protocol. This creates an on-chain record that establishes trust.
+When you deploy a schema, your wallet address is recorded as its authority. This gives you permanent control over that schema.
 
-### Registration Requirements
-
-| Requirement | Description |
-|-------------|-------------|
-| **Stellar Address** | A valid Stellar account to serve as the authority |
-| **Registration Fee** | 100 XLM fee to prevent spam registrations |
-| **Metadata** | JSON-formatted information about the authority |
-
-### Using the SDK
+### Creating a Schema
 
 ```typescript
 import { StellarAttest } from '@attestprotocol/stellar-sdk';
@@ -55,9 +56,58 @@ const attest = new StellarAttest({
   contractId: 'CBFE5YSUHCRYEYEOLNN2RJAWMQ2PW525KTJ6TPWPNS5XLIREZQ3NA4KP'
 });
 
-// Register as an authority
+// Deploy a schema - you automatically become its authority
+const schemaUid = await attest.schema.register({
+  schema: 'string name, bool verified, uint64 timestamp',
+  resolver: resolverAddress, // Optional custom resolver
+  revocable: true
+});
+
+// Your wallet is now the authority of this schema
+```
+
+### Authority Permissions
+
+As a schema authority, you can:
+
+| Permission | Description |
+|------------|-------------|
+| **Issue Attestations** | Create verifiable claims following your schema |
+| **Revoke Attestations** | Invalidate previously issued attestations (if schema allows) |
+| **Set Resolver** | Define custom validation rules at schema creation |
+| **Delegate Signing** | Allow delegates to sign on your behalf (via BLS delegation) |
+
+<Info>
+Schema ownership is permanent. Once you deploy a schema, the authority field cannot be changed.
+</Info>
+
+## Verified Authority (Optional)
+
+Becoming a **Verified Authority** is optional but provides trust signals on the AttestProtocol platform:
+
+- **Platform badge** — Visual indicator that you're a verified issuer
+- **Trust signals** — Users can see your verification status
+- **Discovery** — Easier for verifiers to find trusted attestation sources
+
+### Verification Methods
+
+You can verify your authority through multiple methods:
+
+<CardGroup cols={2}>
+  <Card title="stellar.toml" icon="star">
+    For Stellar-native organizations, verify using your domain's stellar.toml file
+  </Card>
+  <Card title="DID & Verifiable Credentials" icon="fingerprint">
+    Use decentralized identifiers and external credentials for verification
+  </Card>
+</CardGroup>
+
+### Registering as a Verified Authority
+
+```typescript
+// Register for verified authority status
 const result = await attest.authority.registerAuthority(
-  'GAUTHORITY...', // Authority address
+  'GAUTHORITY...', // Your authority address
   JSON.stringify({
     name: 'Acme Verification Inc.',
     website: 'https://acme.com',
@@ -69,25 +119,13 @@ const result = await attest.authority.registerAuthority(
 ### Using the CLI
 
 ```bash
-# Register the current wallet as an authority
+# Register for verified authority status
 pnpm cli authority --chain stellar --action register --key-file ./keypair.json
 ```
 
-## Authority Properties
+## Authority Metadata
 
-Each registered authority has the following on-chain properties:
-
-```typescript
-interface Authority {
-  address: string;      // Stellar address of the authority
-  metadata: string;     // JSON metadata (name, website, etc.)
-  isVerified: boolean;  // Verification status
-}
-```
-
-### Metadata Best Practices
-
-Include relevant information in your authority metadata:
+When registering as a verified authority, include relevant information:
 
 ```json
 {
@@ -100,47 +138,28 @@ Include relevant information in your authority metadata:
 }
 ```
 
-## Authority Verification
+## Checking Authority Status
 
-Authorities can be verified by protocol administrators. Verification provides an additional layer of trust for consumers of attestations.
+### Check Schema Authority
+
+Every attestation includes the attester address, letting verifiers know who issued it:
 
 ```typescript
-// Check if an authority is verified
-const isVerified = await attest.authority.isAuthority('GAUTHORITY...');
+// Get attestation details
+const attestation = await attest.getAttestation(attestationUid);
+console.log('Issued by:', attestation.data.attester);
+```
+
+### Check Verified Authority Status
+
+```typescript
+// Check if an address is a verified authority
+const isVerified = await attest.authority.isAuthority('GADDRESS...');
 
 // Fetch full authority details
-const authority = await attest.authority.fetchAuthority('GAUTHORITY...');
-console.log(authority.data);
+const authority = await attest.authority.fetchAuthority('GADDRESS...');
+console.log('Authority:', authority.data);
 ```
-
-## Authority Permissions
-
-Once registered, an authority can:
-
-| Permission | Description |
-|------------|-------------|
-| **Create Schemas** | Define new attestation types with custom fields |
-| **Issue Attestations** | Create verifiable claims following their schemas |
-| **Revoke Attestations** | Invalidate previously issued attestations (if schema allows) |
-| **Collect Fees** | Optionally charge for attestation services via resolvers |
-| **Delegate Signing** | Allow delegates to sign on their behalf (via BLS delegation) |
-
-## Schema Ownership
-
-When an authority creates a schema, they become the permanent owner:
-
-```typescript
-// Authority creates a schema
-const schemaUid = await attest.schema.register({
-  schema: 'string name, bool verified, uint64 timestamp',
-  resolver: resolverAddress, // Optional custom resolver
-  revocable: true
-});
-
-// The authority field is automatically set to the caller
-```
-
-The authority field in a schema cannot be changed after creation. This ensures that schema ownership is permanent and verifiable.
 
 ## Delegation
 
@@ -152,54 +171,32 @@ Authorities can delegate attestation signing to other addresses using BLS delega
 
 See [Delegation](/concepts/delegation) for detailed documentation.
 
+## Authority vs Resolver
+
+While authorities control **who owns schemas**, resolvers control **the rules** for attestation creation:
+
+| Aspect | Authority | Resolver |
+|--------|-----------|----------|
+| **Purpose** | Schema ownership | Enforces business rules |
+| **Assignment** | Automatic on schema creation | Optional, attached to schemas |
+| **Control** | Creates schemas, issues attestations | Validates attestation operations |
+| **Examples** | KYC provider, DAO, certification body | Payment validation, access control |
+
+See [Custom Resolvers](/concepts/resolvers) for more on implementing validation logic.
+
 ## Security Considerations
 
 <Warning>
-Your authority address controls all schemas and attestations you create. Keep your private keys secure and consider using multi-signature setups for high-value authorities.
+Your authority address controls all schemas you create. Keep your private keys secure.
 </Warning>
 
 ### Best Practices
 
 1. **Use a dedicated address** — Don't reuse addresses across protocols
 2. **Secure your keys** — Use hardware wallets or multi-sig for production
-3. **Verify metadata** — Ensure your `stellar.toml` matches your registration
+3. **Verify your domain** — Set up stellar.toml for additional trust
 4. **Monitor attestations** — Track what's being issued under your authority
 5. **Plan revocation** — Have a process for revoking compromised attestations
-
-## Authority vs Resolver
-
-While authorities control **who can issue** attestations, resolvers control **the rules** for attestation creation:
-
-| Aspect | Authority | Resolver |
-|--------|-----------|----------|
-| **Purpose** | Establishes trust/identity | Enforces business rules |
-| **Registration** | One-time with fee | Attached to schemas |
-| **Control** | Creates schemas, issues attestations | Validates attestation operations |
-| **Examples** | KYC provider, DAO, certification body | Payment validation, access control |
-
-See [Custom Resolvers](/concepts/resolvers) for more on implementing validation logic.
-
-## Querying Authorities
-
-### Check Authority Status
-
-```typescript
-// Verify if an address is a registered authority
-const isAuthority = await attest.authority.isAuthority('GADDRESS...');
-
-if (isAuthority.data) {
-  console.log('This address is a registered authority');
-}
-```
-
-### Fetch Authority Details
-
-```typescript
-// Get full authority information
-const authority = await attest.authority.fetchAuthority('GADDRESS...');
-
-console.log('Authority:', authority.data.metadata);
-```
 
 ## Next Steps
 

--- a/apps/docs/concepts/authorities.mdx
+++ b/apps/docs/concepts/authorities.mdx
@@ -1,0 +1,219 @@
+---
+title: "Authorities"
+description: "The trust layer that governs who can issue attestations"
+---
+
+## What is an Authority?
+
+An Authority is a registered entity that has the right to create schemas and issue attestations. Think of authorities as **trusted issuers** — they're the organizations, protocols, or individuals that vouch for the claims being made on-chain.
+
+<Note>
+Authorities are the foundation of trust in the attestation ecosystem. Without a registered authority, you cannot create schemas or issue attestations.
+</Note>
+
+## The Authority Model
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      AUTHORITY LAYER                        │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   Authority                                                 │
+│   ├── Registers with Protocol (pays fee)                   │
+│   ├── Creates Schema(s)                                    │
+│   │   ├── Defines attestation structure                    │
+│   │   ├── Sets resolver (optional)                         │
+│   │   └── Configures revocability                          │
+│   │                                                         │
+│   └── Issues Attestation(s)                                │
+│       ├── Signs claims about subjects                      │
+│       ├── Follows schema structure                         │
+│       └── Can revoke (if schema allows)                    │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Authority Registration
+
+Before issuing attestations, an authority must register with the protocol. This creates an on-chain record that establishes trust.
+
+### Registration Requirements
+
+| Requirement | Description |
+|-------------|-------------|
+| **Stellar Address** | A valid Stellar account to serve as the authority |
+| **Registration Fee** | 100 XLM fee to prevent spam registrations |
+| **Metadata** | JSON-formatted information about the authority |
+
+### Using the SDK
+
+```typescript
+import { StellarAttest } from '@attestprotocol/stellar-sdk';
+
+const attest = new StellarAttest({
+  network: 'testnet',
+  contractId: 'CBFE5YSUHCRYEYEOLNN2RJAWMQ2PW525KTJ6TPWPNS5XLIREZQ3NA4KP'
+});
+
+// Register as an authority
+const result = await attest.authority.registerAuthority(
+  'GAUTHORITY...', // Authority address
+  JSON.stringify({
+    name: 'Acme Verification Inc.',
+    website: 'https://acme.com',
+    description: 'KYC and identity verification provider'
+  })
+);
+```
+
+### Using the CLI
+
+```bash
+# Register the current wallet as an authority
+pnpm cli authority --chain stellar --action register --key-file ./keypair.json
+```
+
+## Authority Properties
+
+Each registered authority has the following on-chain properties:
+
+```typescript
+interface Authority {
+  address: string;      // Stellar address of the authority
+  metadata: string;     // JSON metadata (name, website, etc.)
+  isVerified: boolean;  // Verification status
+}
+```
+
+### Metadata Best Practices
+
+Include relevant information in your authority metadata:
+
+```json
+{
+  "name": "Your Organization Name",
+  "website": "https://your-domain.com",
+  "description": "Brief description of what you attest to",
+  "logo": "https://your-domain.com/logo.png",
+  "contact": "attestations@your-domain.com",
+  "categories": ["identity", "kyc", "credentials"]
+}
+```
+
+## Authority Verification
+
+Authorities can be verified by protocol administrators. Verification provides an additional layer of trust for consumers of attestations.
+
+```typescript
+// Check if an authority is verified
+const isVerified = await attest.authority.isAuthority('GAUTHORITY...');
+
+// Fetch full authority details
+const authority = await attest.authority.fetchAuthority('GAUTHORITY...');
+console.log(authority.data);
+```
+
+## Authority Permissions
+
+Once registered, an authority can:
+
+| Permission | Description |
+|------------|-------------|
+| **Create Schemas** | Define new attestation types with custom fields |
+| **Issue Attestations** | Create verifiable claims following their schemas |
+| **Revoke Attestations** | Invalidate previously issued attestations (if schema allows) |
+| **Collect Fees** | Optionally charge for attestation services via resolvers |
+| **Delegate Signing** | Allow delegates to sign on their behalf (via BLS delegation) |
+
+## Schema Ownership
+
+When an authority creates a schema, they become the permanent owner:
+
+```typescript
+// Authority creates a schema
+const schemaUid = await attest.schema.register({
+  schema: 'string name, bool verified, uint64 timestamp',
+  resolver: resolverAddress, // Optional custom resolver
+  revocable: true
+});
+
+// The authority field is automatically set to the caller
+```
+
+The authority field in a schema cannot be changed after creation. This ensures that schema ownership is permanent and verifiable.
+
+## Delegation
+
+Authorities can delegate attestation signing to other addresses using BLS delegation. This enables:
+
+- **Gasless attestations** — Users sign off-chain, a relayer submits on-chain
+- **Batch operations** — Issue many attestations in one transaction
+- **Separation of concerns** — Keep hot wallets separate from authority keys
+
+See [Delegation](/concepts/delegation) for detailed documentation.
+
+## Security Considerations
+
+<Warning>
+Your authority address controls all schemas and attestations you create. Keep your private keys secure and consider using multi-signature setups for high-value authorities.
+</Warning>
+
+### Best Practices
+
+1. **Use a dedicated address** — Don't reuse addresses across protocols
+2. **Secure your keys** — Use hardware wallets or multi-sig for production
+3. **Verify metadata** — Ensure your `stellar.toml` matches your registration
+4. **Monitor attestations** — Track what's being issued under your authority
+5. **Plan revocation** — Have a process for revoking compromised attestations
+
+## Authority vs Resolver
+
+While authorities control **who can issue** attestations, resolvers control **the rules** for attestation creation:
+
+| Aspect | Authority | Resolver |
+|--------|-----------|----------|
+| **Purpose** | Establishes trust/identity | Enforces business rules |
+| **Registration** | One-time with fee | Attached to schemas |
+| **Control** | Creates schemas, issues attestations | Validates attestation operations |
+| **Examples** | KYC provider, DAO, certification body | Payment validation, access control |
+
+See [Custom Resolvers](/concepts/resolvers) for more on implementing validation logic.
+
+## Querying Authorities
+
+### Check Authority Status
+
+```typescript
+// Verify if an address is a registered authority
+const isAuthority = await attest.authority.isAuthority('GADDRESS...');
+
+if (isAuthority.data) {
+  console.log('This address is a registered authority');
+}
+```
+
+### Fetch Authority Details
+
+```typescript
+// Get full authority information
+const authority = await attest.authority.fetchAuthority('GADDRESS...');
+
+console.log('Authority:', authority.data.metadata);
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Create Your First Schema" icon="square-plus" href="/stellar/schemas">
+    Define attestation structures for your use case
+  </Card>
+  <Card title="Custom Resolvers" icon="code" href="/concepts/resolvers">
+    Add validation rules to your attestations
+  </Card>
+  <Card title="Delegation" icon="signature" href="/concepts/delegation">
+    Enable off-chain signing with BLS delegation
+  </Card>
+  <Card title="Examples" icon="book-open" href="/examples/kyc-verification">
+    See real-world authority implementations
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/resolvers.mdx
+++ b/apps/docs/concepts/resolvers.mdx
@@ -1,0 +1,413 @@
+---
+title: "Custom Resolvers"
+description: "Define rules about who can attest to a schema"
+---
+
+## What are Resolvers?
+
+Resolvers are smart contracts that define **custom validation rules** for attestations. When you attach a resolver to a schema, every attestation must pass through the resolver's validation logic before being created.
+
+<Note>
+Think of resolvers as gatekeepers — they control the conditions under which attestations can be created or revoked.
+</Note>
+
+## Why Use Resolvers?
+
+Without resolvers, any authority can issue attestations on any schema. Resolvers let you:
+
+- **Control access** — Only allow specific addresses to attest
+- **Collect fees** — Require payment before attestation creation
+- **Distribute rewards** — Incentivize attestation with token rewards
+- **Enforce rules** — Implement custom business logic
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                    ATTESTATION FLOW                            │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│   1. Attestation Request                                       │
+│          │                                                     │
+│          ▼                                                     │
+│   2. Resolver.onattest()  ──── Validation ────┐                │
+│          │                                    │                │
+│          ▼ (if approved)                      ▼ (if rejected)  │
+│   3. Store Attestation                   ❌ Error              │
+│          │                                                     │
+│          ▼                                                     │
+│   4. Resolver.onresolve()  ──── Post-processing                │
+│          │                                                     │
+│          ▼                                                     │
+│   ✅ Attestation Created                                       │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Resolver Interface
+
+All resolvers implement the same interface, making them pluggable and interchangeable:
+
+```rust
+pub trait ResolverInterface {
+    // Validate before attestation creation
+    fn onattest(env: Env, attestation: ResolverAttestationData) -> Result<bool, ResolverError>;
+
+    // Validate before attestation revocation
+    fn onrevoke(env: Env, attestation: ResolverAttestationData) -> Result<bool, ResolverError>;
+
+    // Post-processing callback (after creation/revocation)
+    fn onresolve(env: Env, attestation_uid: BytesN<32>, attester: Address) -> Result<(), ResolverError>;
+
+    // Resolver metadata for discovery
+    fn metadata(env: Env) -> ResolverMetadata;
+}
+```
+
+### Hook Functions
+
+| Function | When Called | Purpose | Critical? |
+|----------|-------------|---------|-----------|
+| `onattest` | Before attestation creation | Validate and gate access | Yes |
+| `onrevoke` | Before attestation revocation | Validate revocation permission | Yes |
+| `onresolve` | After creation/revocation | Post-processing (rewards, cleanup) | No |
+| `metadata` | On query | Return resolver information | No |
+
+<Warning>
+**Critical vs Non-Critical:** If `onattest` or `onrevoke` fails, the operation is aborted. If `onresolve` fails, the attestation still succeeds — it's for side effects only.
+</Warning>
+
+## Attestation Data
+
+Resolvers receive complete attestation data for validation:
+
+```rust
+pub struct ResolverAttestationData {
+    pub uid: BytesN<32>,           // Unique attestation ID
+    pub schema_uid: BytesN<32>,    // Associated schema
+    pub recipient: Address,        // Who is being attested about
+    pub attester: Address,         // Who is attesting
+    pub time: u64,                 // Creation timestamp
+    pub expiration_time: u64,      // When it expires (0 = never)
+    pub revocation_time: u64,      // When revoked (0 = not revoked)
+    pub revocable: bool,           // Can be revoked?
+    pub ref_uid: Bytes,            // Reference to another attestation
+    pub data: Bytes,               // Encoded attestation data
+    pub value: i128,               // Optional payment value
+}
+```
+
+## Resolver Types
+
+### Default Resolver
+
+The simplest resolver — validates basic rules without economic requirements.
+
+```rust
+impl ResolverInterface for DefaultResolver {
+    fn onattest(env: Env, attestation: ResolverAttestationData) -> Result<bool, ResolverError> {
+        // Require attester authorization
+        attestation.attester.require_auth();
+
+        // Prevent self-attestation
+        if attestation.attester == attestation.recipient {
+            return Err(ResolverError::ValidationFailed);
+        }
+
+        // Validate expiration
+        if attestation.expiration_time > 0
+            && attestation.expiration_time < env.ledger().timestamp() {
+            return Err(ResolverError::InvalidAttestation);
+        }
+
+        Ok(true)
+    }
+}
+```
+
+**Use cases:**
+- Development and testing
+- Schemas without special requirements
+- Base implementation for custom resolvers
+
+### Fee Collection Resolver
+
+Requires payment before attestation creation.
+
+```rust
+impl ResolverInterface for FeeCollectionResolver {
+    fn onattest(env: Env, attestation: ResolverAttestationData) -> Result<bool, ResolverError> {
+        attestation.attester.require_auth();
+
+        // Check payment amount
+        let required_fee = get_attestation_fee(&env);
+        if attestation.value < required_fee {
+            return Err(ResolverError::InsufficientFunds);
+        }
+
+        // Collect the fee
+        collect_fee(&env, &attestation.attester, attestation.value)?;
+
+        Ok(true)
+    }
+}
+```
+
+**Use cases:**
+- Monetizing attestation services
+- Spam prevention through economic cost
+- Revenue generation for attestation providers
+
+### Token Reward Resolver
+
+Distributes token rewards for attestation creation.
+
+```rust
+impl ResolverInterface for TokenRewardResolver {
+    fn onattest(_env: Env, _attestation: ResolverAttestationData) -> Result<bool, ResolverError> {
+        // Permissionless - gas cost provides spam resistance
+        Ok(true)
+    }
+
+    fn onresolve(env: Env, _attestation_uid: BytesN<32>, attester: Address) -> Result<(), ResolverError> {
+        // Distribute reward after attestation
+        let reward_amount = get_reward_amount(&env);
+        distribute_reward(&env, &attester, reward_amount)?;
+        Ok(())
+    }
+}
+```
+
+**Use cases:**
+- Incentivizing attestation creation
+- Community engagement programs
+- Protocol growth mechanics
+
+### Authority Resolver
+
+Permission-based access control with verification.
+
+```rust
+impl ResolverInterface for AuthorityResolver {
+    fn onattest(env: Env, attestation: ResolverAttestationData) -> Result<bool, ResolverError> {
+        attestation.attester.require_auth();
+
+        // Check if attester is a registered authority
+        if !is_registered_authority(&env, &attestation.attester) {
+            return Err(ResolverError::NotAuthorized);
+        }
+
+        Ok(true)
+    }
+}
+```
+
+**Use cases:**
+- Restricted attestation environments
+- Verified issuer programs
+- Credentialed attestation systems
+
+## Creating a Custom Resolver
+
+### Step 1: Implement the Interface
+
+```rust
+use soroban_sdk::{contract, contractimpl, Env, Address, BytesN, String};
+use resolvers::{ResolverInterface, ResolverAttestationData, ResolverError, ResolverMetadata, ResolverType};
+
+#[contract]
+pub struct MyCustomResolver;
+
+#[contractimpl]
+impl ResolverInterface for MyCustomResolver {
+    fn onattest(env: Env, attestation: ResolverAttestationData) -> Result<bool, ResolverError> {
+        // Your validation logic here
+        attestation.attester.require_auth();
+
+        // Example: Only allow attestations on weekdays
+        // (This is just an example - implement your own logic)
+
+        Ok(true)
+    }
+
+    fn onrevoke(env: Env, attestation: ResolverAttestationData) -> Result<bool, ResolverError> {
+        attestation.attester.require_auth();
+
+        if !attestation.revocable {
+            return Err(ResolverError::ValidationFailed);
+        }
+
+        Ok(true)
+    }
+
+    fn onresolve(_env: Env, _attestation_uid: BytesN<32>, _attester: Address) -> Result<(), ResolverError> {
+        // Optional post-processing
+        Ok(())
+    }
+
+    fn metadata(env: Env) -> ResolverMetadata {
+        ResolverMetadata {
+            name: String::from_str(&env, "My Custom Resolver"),
+            version: String::from_str(&env, "1.0.0"),
+            description: String::from_str(&env, "Custom validation for my use case"),
+            resolver_type: ResolverType::Custom,
+        }
+    }
+}
+```
+
+### Step 2: Build the Contract
+
+```bash
+cargo build --target wasm32v1-none --release
+```
+
+### Step 3: Deploy to Stellar
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/my_resolver.wasm \
+  --source YOUR_IDENTITY \
+  --network testnet
+```
+
+### Step 4: Attach to a Schema
+
+```typescript
+const schemaUid = await attest.schema.register({
+  schema: 'string credential, uint64 issuedAt',
+  resolver: 'CRESOLVER...', // Your deployed resolver address
+  revocable: true
+});
+```
+
+## Binding Resolvers to Schemas
+
+When you create a schema, you can optionally attach a resolver:
+
+```typescript
+import { StellarAttest } from '@attestprotocol/stellar-sdk';
+
+const attest = new StellarAttest({ network: 'testnet' });
+
+// Schema with a resolver
+const schemaWithResolver = await attest.schema.register({
+  schema: 'string credential, bool verified',
+  resolver: 'CRESOLVER...', // Resolver contract address
+  revocable: true
+});
+
+// Schema without a resolver (no validation)
+const schemaWithoutResolver = await attest.schema.register({
+  schema: 'string note',
+  resolver: null, // No resolver
+  revocable: false
+});
+```
+
+<Info>
+Once a schema is created, its resolver cannot be changed. Choose your resolver carefully before deploying to production.
+</Info>
+
+## Error Handling
+
+Resolvers use a standard error enum:
+
+```rust
+#[contracterror]
+pub enum ResolverError {
+    NotAuthorized = 1,      // Caller lacks permission
+    InvalidAttestation = 2, // Attestation data is invalid
+    InvalidSchema = 3,      // Schema mismatch
+    InsufficientFunds = 4,  // Payment too low
+    TokenTransferFailed = 5,// Token operation failed
+    StakeRequired = 6,      // Staking requirement not met
+    ValidationFailed = 7,   // Generic validation failure
+    CustomError = 8,        // Custom error condition
+}
+```
+
+## Security Considerations
+
+<Warning>
+Resolver bugs can lead to unauthorized attestations or denial of service. Test thoroughly before production deployment.
+</Warning>
+
+### Best Practices
+
+1. **Always require auth** — Call `require_auth()` on the attester
+2. **Validate all inputs** — Don't trust data from the protocol
+3. **Handle failures gracefully** — Return proper error codes
+4. **Avoid state dependencies** — Don't rely on external state that can be manipulated
+5. **Test edge cases** — Expired attestations, revocations, etc.
+
+### Common Pitfalls
+
+| Pitfall | Issue | Solution |
+|---------|-------|----------|
+| Missing auth check | Anyone can attest | Always call `require_auth()` |
+| Self-attestation | Users attest to themselves | Check `attester != recipient` |
+| Expired data | Using outdated timestamps | Validate against current time |
+| Reentrancy | Token callbacks | Use checks-effects-interactions pattern |
+
+## Testing Resolvers
+
+```rust
+#[test]
+fn test_reject_self_attestation() {
+    let (env, resolver) = setup();
+    let user = Address::generate(&env);
+
+    let attestation = build_attestation(&env, &user, &user, 0);
+
+    let result = resolver.try_onattest(&attestation);
+    assert!(matches!(result.err(), Some(Ok(ResolverError::ValidationFailed))));
+}
+
+#[test]
+fn test_accept_valid_attestation() {
+    let (env, resolver) = setup();
+    let attester = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let attestation = build_attestation(&env, &attester, &recipient, 0);
+
+    assert!(resolver.onattest(&attestation));
+}
+```
+
+## Built-in Resolvers
+
+The protocol provides pre-built resolvers you can use:
+
+| Resolver | Purpose | Build Command |
+|----------|---------|---------------|
+| Default | Basic validation | `--features export-default-resolver` |
+| Token Reward | Distribute rewards | `--features export-token-reward-resolver` |
+| Fee Collection | Collect fees | `--features export-fee-collection-resolver` |
+
+```bash
+# Build the default resolver
+cargo build --target wasm32v1-none --release --features export-default-resolver
+
+# Deploy
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/resolvers.wasm \
+  --source YOUR_IDENTITY \
+  --network testnet
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Authorities" icon="shield" href="/concepts/authorities">
+    Understand the trust layer for attestation issuers
+  </Card>
+  <Card title="Schemas" icon="database" href="/concepts/schemas">
+    Define attestation structures with resolver bindings
+  </Card>
+  <Card title="Stellar Overview" icon="star" href="/chains/stellar/overview">
+    Deep dive into Stellar contract architecture
+  </Card>
+  <Card title="GitHub" icon="github" href="https://github.com/daccred/attest.so/tree/main/contracts/stellar/resolvers">
+    Browse resolver source code
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/resolvers.mdx
+++ b/apps/docs/concepts/resolvers.mdx
@@ -8,12 +8,14 @@ description: "Define rules about who can attest to a schema"
 Resolvers are smart contracts that define **custom validation rules** for attestations. When you attach a resolver to a schema, every attestation must pass through the resolver's validation logic before being created.
 
 <Note>
-Think of resolvers as gatekeepers — they control the conditions under which attestations can be created or revoked.
+Schemas and attestations are **permissionless by default**. Resolvers are how you add access control, fees, or custom rules when you need them.
 </Note>
 
 ## Why Use Resolvers?
 
-Without resolvers, any authority can issue attestations on any schema. Resolvers let you:
+By default, **anyone can attest to any schema**. This permissionless model is intentional — it enables open, composable attestations. But sometimes you need control:
+
+Resolvers let you:
 
 - **Control access** — Only allow specific addresses to attest
 - **Collect fees** — Require payment before attestation creation
@@ -22,7 +24,15 @@ Without resolvers, any authority can issue attestations on any schema. Resolvers
 
 ```
 ┌────────────────────────────────────────────────────────────────┐
-│                    ATTESTATION FLOW                            │
+│              WITHOUT RESOLVER (Permissionless)                 │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│   Anyone ──► Attest to Any Schema ──► ✅ Attestation Created   │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────┐
+│               WITH RESOLVER (Access Control)                   │
 ├────────────────────────────────────────────────────────────────┤
 │                                                                │
 │   1. Attestation Request                                       │
@@ -295,10 +305,10 @@ const schemaWithResolver = await attest.schema.register({
   revocable: true
 });
 
-// Schema without a resolver (no validation)
+// Schema without a resolver (permissionless - anyone can attest)
 const schemaWithoutResolver = await attest.schema.register({
   schema: 'string note',
-  resolver: null, // No resolver
+  resolver: null, // No resolver = anyone can attest
   revocable: false
 });
 ```

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -33,6 +33,8 @@
             "group": "Concepts",
             "pages": [
               "concepts/how-it-works",
+              "concepts/authorities",
+              "concepts/resolvers",
               "concepts/attestations",
               "concepts/schemas",
               "concepts/delegation"

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -1,11 +1,25 @@
 ---
 title: "Introduction"
-description: "Decentralized attestation infrastructure for onchain reputation"
+description: "Add proof to anything, on-chain without writing a line of code"
 ---
 
-## What is AttestProtocol?
+## Whenever you need to prove something onchain — *identity, action, ownership, or permission* — you don't need to write a new smart contract or spin up a ZK system.
 
-A shared, on-chain attestation registry for issuing and verifying credentials. Create verifiable claims about users, assets, or events that any application can read and trust.
+Attest provides a proof infrastructure to build anything from **network states, DAOs, DePIN, and RWA**. With our **Unified Trust Framework,** developers on Stellar can integrate reputation and trust mechanisms in their dApps.
+
+## Add proof to anything, on-chain without writing a line of code.
+
+AttestProtocol is a Soroban-based framework that lets you attach attestations to any wallet, asset, or event. Whether that's *proof of identity, contribution, credential, or ownership.* No contracts, no infrastructure, no ZK black magic required.
+
+<Tip>
+Think of it like SSL for blockchains — a lightweight trust signal you can apply anywhere.
+</Tip>
+
+## An Open Standard for Trust
+
+Using our **Attestation Service** you get an open standard for verifying *statements, transactions, and authorities* — identity proofs **on the blockchain**.
+
+Our **Soroban framework** enhances the reliability of digital interactions on the Stellar Network with a composable blockchain-based **Attestation Service.**
 
 ## Use Cases
 
@@ -54,6 +68,8 @@ Teams building:
 
 | Feature              | Description                                                       |
 | -------------------- | ----------------------------------------------------------------- |
+| **Authorities**      | Register as a trusted issuer and create custom attestation schemas |
+| **Custom Resolvers** | Define rules about who can attest — fees, permissions, rewards    |
 | **BLS Delegation**   | Sign attestations off-chain, submit on-chain. Submitter pays gas. |
 | **Flexible Schemas** | Define custom attestation structures for any use case             |
 | **Multi-Chain**      | Stellar (production) + Solana (beta)                              |
@@ -72,13 +88,13 @@ Teams building:
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Create your first attestation in 5 minutes
   </Card>
+  <Card title="Authorities" icon="shield" href="/concepts/authorities">
+    Register as a trusted attestation issuer
+  </Card>
+  <Card title="Custom Resolvers" icon="code" href="/concepts/resolvers">
+    Define custom validation rules for attestations
+  </Card>
   <Card title="How It Works" icon="lightbulb" href="/concepts/how-it-works">
     Understand the architecture
-  </Card>
-  <Card title="Examples" icon="code" href="/examples/react-integration">
-    Real-world integration patterns
-  </Card>
-  <Card title="GitHub" icon="github" href="https://github.com/daccred/attest.so">
-    Source code
   </Card>
 </CardGroup>


### PR DESCRIPTION
- Add concepts/authorities.mdx explaining the authority layer for attestation issuers
- Add concepts/resolvers.mdx documenting custom resolver contracts and validation rules
- Update introduction.mdx with new messaging about proof infrastructure
- Update docs.json navigation to include new concept pages

## I have read the [CONTRIBUTING.md](https://github.com/daccred/attest.so/blob/main/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
